### PR TITLE
binlog_format=mixed

### DIFF
--- a/root/defaults/my.cnf
+++ b/root/defaults/my.cnf
@@ -13,6 +13,7 @@ sort_buffer_size	= 4M
 bulk_insert_buffer_size	= 16M
 tmp_table_size		= 32M
 max_heap_table_size	= 32M
+binlog_format=mixed
 #
 # * MyISAM
 #

--- a/root/defaults/my.cnf
+++ b/root/defaults/my.cnf
@@ -13,7 +13,6 @@ sort_buffer_size	= 4M
 bulk_insert_buffer_size	= 16M
 tmp_table_size		= 32M
 max_heap_table_size	= 32M
-binlog_format=mixed
 #
 # * MyISAM
 #
@@ -116,7 +115,7 @@ innodb_flush_method	= O_DIRECT
 #wsrep_on=ON
 #wsrep_provider=
 #wsrep_cluster_address=
-#binlog_format=row
+binlog_format=mixed
 #default_storage_engine=InnoDB
 #innodb_autoinc_lock_mode=2
 #


### PR DESCRIPTION
According to mariadb website, binlog_format=mixed is the default setting for versions above 10.2.4: https://mariadb.com/kb/en/mariadb/binary-log-formats/

Plus, nextcloud requires it.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

